### PR TITLE
Cross Platform Notifications (linux, mac, windows).

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,16 +2,22 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/jawher/mow.cli"
 	"os"
 	"runtime"
 	"sort"
 	"time"
+
+	"github.com/jawher/mow.cli"
 )
 
 func notifier(iconPath string) Notifier {
-	if runtime.GOOS == "linux" {
+	switch runtime.GOOS {
+	case "linux":
 		return NewLibNotifier(iconPath)
+	case "darwin":
+		return NewAllNotifier(iconPath)
+	case "windows":
+		return NewAllNotifier(iconPath)
 	}
 	return NoopNotifier{}
 }

--- a/main.go
+++ b/main.go
@@ -15,9 +15,9 @@ func notifier(iconPath string) Notifier {
 	case "linux":
 		return NewLibNotifier(iconPath)
 	case "darwin":
-		return NewAllNotifier(iconPath)
+		return NewDarwinNotifier(iconPath)
 	case "windows":
-		return NewAllNotifier(iconPath)
+		return NewWindowsNotifier(iconPath)
 	}
 	return NoopNotifier{}
 }

--- a/types.go
+++ b/types.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/0xAX/notificator"
 	"github.com/fatih/color"
 
 	"github.com/kevinschoon/pomo/libnotify"
@@ -184,13 +185,13 @@ func (ln LibNotifier) Notify(title, body string) error {
 	)
 }
 
-// notificator can push notifications to mac, linux and windows.
-type notificator struct {
+// xnotifier can push notifications to mac, linux and windows.
+type xnotifier struct {
 	*notificator.Notificator
 	iconPath string
 }
 
-func newNotificator(iconPath string) notificator {
+func newXnotifier(iconPath string) xnotifier {
 	// Write the built-in tomato icon if it
 	// doesn't already exist.
 	_, err := os.Stat(iconPath)
@@ -198,25 +199,25 @@ func newNotificator(iconPath string) notificator {
 		raw := MustAsset("tomato-icon.png")
 		_ = ioutil.WriteFile(iconPath, raw, 0644)
 	}
-	return notificator{
+	return xnotifier{
 		Notificator: notificator.New(notificator.Options{}),
 		iconPath:    iconPath,
 	}
 }
 
 // Notify sends a notification to the OS.
-func (n notificator) Notify(title, body string) error {
+func (n xnotifier) Notify(title, body string) error {
 	return n.Push(title, body, n.iconPath, notificator.UR_NORMAL)
 }
 
-type DarwinNotifier = notificator
+type DarwinNotifier = xnotifier
 
 func NewDarwinNotifier(iconPath string) DarwinNotifier {
-	return newNotificator(iconPath)
+	return newXnotifier(iconPath)
 }
 
-type WindowsNotifier = notificator
+type WindowsNotifier = xnotifier
 
 func NewWindowsNotifier(iconPath string) WindowsNotifier {
-	return newNotificator(iconPath)
+	return newXnotifier(iconPath)
 }

--- a/types.go
+++ b/types.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/0xAX/notificator"
 	"github.com/fatih/color"
 
 	"github.com/kevinschoon/pomo/libnotify"
@@ -185,15 +184,13 @@ func (ln LibNotifier) Notify(title, body string) error {
 	)
 }
 
-// AllNotifier can push notifications to mac, linux and windows.
-// Icon can be specified via file path.
-type AllNotifier struct {
+// notificator can push notifications to mac, linux and windows.
+type notificator struct {
 	*notificator.Notificator
 	iconPath string
 }
 
-// NewAllNotifier constructs an AllNotifier object.
-func NewAllNotifier(iconPath string) AllNotifier {
+func newNotificator(iconPath string) notificator {
 	// Write the built-in tomato icon if it
 	// doesn't already exist.
 	_, err := os.Stat(iconPath)
@@ -201,13 +198,25 @@ func NewAllNotifier(iconPath string) AllNotifier {
 		raw := MustAsset("tomato-icon.png")
 		_ = ioutil.WriteFile(iconPath, raw, 0644)
 	}
-	return AllNotifier{
+	return notificator{
 		Notificator: notificator.New(notificator.Options{}),
 		iconPath:    iconPath,
 	}
 }
 
 // Notify sends a notification to the OS.
-func (n AllNotifier) Notify(title, body string) error {
+func (n notificator) Notify(title, body string) error {
 	return n.Push(title, body, n.iconPath, notificator.UR_NORMAL)
+}
+
+type DarwinNotifier = notificator
+
+func NewDarwinNotifier(iconPath string) DarwinNotifier {
+	return newNotificator(iconPath)
+}
+
+type WindowsNotifier = notificator
+
+func NewWindowsNotifier(iconPath string) WindowsNotifier {
+	return newNotificator(iconPath)
 }


### PR DESCRIPTION
Simple implementation wrapping https://github.com/0xAX/notificator which enables mac and windows notifications, obviously linux is all ready implemented. 

The interface `Notify(string, string) error` could be removed in favour of just one concrete implementation using the aforementioned library, but I didn't want to gut the code, merely extend it. 

This results in a little bit of superfluous code, namely the type aliases, and the switch statement that instantiates the specific implementation, can both be done away with. Though I leave that decision up to you!