### PR TITLE
delete socket file after accidental crash

### DIFF
--- a/main.go
+++ b/main.go
@@ -176,14 +176,14 @@ func list(config *Config) func(*cli.Cmd) {
 
 func _delete(config *Config) func(*cli.Cmd) {
 	return func(cmd *cli.Cmd) {
-		cmd.Spec = "[OPTIONS] TASK_ID"
-		var taskID = cmd.IntArg("TASK_ID", -1, "task to delete")
+		cmd.Spec = "TASK_IDS..."
+		ids := cmd.IntsArg("TASK_IDS", nil, "tasks to delete")
 		cmd.Action = func() {
 			db, err := NewStore(config.DBPath)
 			maybe(err)
 			defer db.Close()
 			maybe(db.With(func(tx *sql.Tx) error {
-				return db.DeleteTask(tx, *taskID)
+				return db.DeleteTasks(tx, *ids)
 			}))
 		}
 	}
@@ -233,7 +233,7 @@ func main() {
 	app.Command("create c", "create a new task without starting", create(config))
 	app.Command("begin b", "begin requested pomodoro", begin(config))
 	app.Command("list l", "list historical tasks", list(config))
-	app.Command("delete d", "delete a stored task", _delete(config))
+	app.Command("delete d", "delete a list of stored tasks", _delete(config))
 	app.Command("status st", "output the current status", _status(config))
 	app.Run(os.Args)
 }

--- a/server.go
+++ b/server.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net"
+	"os"
 )
 
 // Server listens on a Unix domain socket
@@ -39,6 +42,17 @@ func (s *Server) Stop() {
 }
 
 func NewServer(runner *TaskRunner, config *Config) (*Server, error) {
+	//check if socket file exists
+	if _, err := os.Stat(config.SocketPath); os.IsExist(err) {
+		_, err := net.Dial("unix", config.SocketPath)
+		//if error then sock file was saved after crash
+		if err != nil {
+			os.Remove(config.SocketPath)
+		} else {
+			// another instance of pomo is running
+			return nil, errors.New(fmt.Sprintf("Socket %s is already in use", config.SocketPath))
+		}
+	}
 	listener, err := net.Listen("unix", config.SocketPath)
 	if err != nil {
 		return nil, err

--- a/store.go
+++ b/store.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"fmt"
 	"strings"
 	"time"
 
@@ -95,14 +96,23 @@ func (s Store) ReadTasks(tx *sql.Tx) ([]*Task, error) {
 	return tasks, nil
 }
 
-func (s Store) DeleteTask(tx *sql.Tx, taskID int) error {
-	_, err := tx.Exec("DELETE FROM task WHERE rowid = $1", &taskID)
-	if err != nil {
-		return err
-	}
-	_, err = tx.Exec("DELETE FROM pomodoro WHERE task_id = $1", &taskID)
-	if err != nil {
-		return err
+func (s Store) DeleteTasks(tx *sql.Tx, taskIds []int) error {
+	for _, id := range taskIds {
+		result, err := tx.Exec("DELETE FROM task WHERE rowid = $1", id)
+		if err != nil {
+			return err
+		}
+		effected, _ := result.RowsAffected()
+		if effected == 0 {
+			fmt.Printf("Task with id [%d] doesn't exist\n", id)
+		} else {
+			_, err = tx.Exec("DELETE FROM pomodoro WHERE task_id = $1", id)
+			if err != nil {
+				return err
+			} else {
+				fmt.Printf("Task with id [%d] was deleted\n", id)
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
If pomo was closed because of system crash or termination then .sock file still exists which doesn't allow a new pomo instance to start with the following error
```
bind: address already in use
```
How to reproduce
1. Start pomo
2. Close terminal

I added new conditions to check if .sock file already exists and if another pomo instance is listening the .sock file  