### PR TITLE
delete socket file after accidental crash

### DIFF
--- a/server.go
+++ b/server.go
@@ -43,7 +43,7 @@ func (s *Server) Stop() {
 
 func NewServer(runner *TaskRunner, config *Config) (*Server, error) {
 	//check if socket file exists
-	if _, err := os.Stat(config.SocketPath); os.IsExist(err) {
+	if _, err := os.Stat(config.SocketPath); err == nil {
 		_, err := net.Dial("unix", config.SocketPath)
 		//if error then sock file was saved after crash
 		if err != nil {

--- a/server.go
+++ b/server.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net"
+	"os"
 )
 
 // Server listens on a Unix domain socket
@@ -39,6 +42,17 @@ func (s *Server) Stop() {
 }
 
 func NewServer(runner *TaskRunner, config *Config) (*Server, error) {
+	//check if socket file exists
+	if _, err := os.Stat(config.SocketPath); os.IsExist(err) {
+		_, err := net.Dial("unix", config.SocketPath)
+		//if error then sock file was saved after crash
+		if err != nil {
+			os.Remove(config.SocketPath)
+		} else {
+			// another instance of pomo is running
+			return nil, errors.New(fmt.Sprintf("Socket %s is already in use", config.SocketPath))
+		}
+	}
 	listener, err := net.Listen("unix", config.SocketPath)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
If pomo was closed because of system crash or termination  close then .sock file still exists which doesn't allow a new pomo instance to start with the following error
```
bind: address already in use
```
How to reproduce
1. Start pomo
2. Close terminal

I added new conditions to check if .sock file already exists and if another pomo instance is listening the .sock file  