### PR TITLE
fix runner test

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -20,6 +20,21 @@ type TaskRunner struct {
 	duration     time.Duration
 }
 
+func NewMockedTaskRunner(task *Task, store *Store, notifier Notifier) (*TaskRunner, error) {
+	tr := &TaskRunner{
+		taskID:       task.ID,
+		taskMessage:  task.Message,
+		nPomodoros:   task.NPomodoros,
+		origDuration: task.Duration,
+		store:        store,
+		state:        State(0),
+		pause:        make(chan bool),
+		toggle:       make(chan bool),
+		notifier:     notifier,
+		duration:     task.Duration,
+	}
+	return tr, nil
+}
 func NewTaskRunner(task *Task, config *Config) (*TaskRunner, error) {
 	store, err := NewStore(config.DBPath)
 	if err != nil {

--- a/runner_test.go
+++ b/runner_test.go
@@ -18,7 +18,7 @@ func TestTaskRunner(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	runner, err := NewTaskRunner(&Task{
+	runner, err := NewMockedTaskRunner(&Task{
 		Duration:   time.Second * 2,
 		NPomodoros: 2,
 		Message:    fmt.Sprint("Test Task"),


### PR DESCRIPTION
runner_test.go doesn't work. How to check. Run `go test`. The output is 
```
# github.com/kevinschoon/pomo [github.com/kevinschoon/pomo.test]
./runner_test.go:21:30: too many arguments in call to NewTaskRunner
	have (*Task, *Store, NoopNotifier)
	want (*Task, *Config)
FAIL	github.com/kevinschoon/pomo [build failed]
```

In this PR I added new constructor to runner for testing and used it in runner_test 