### PR TITLE
Use a separate socket path to publish so pomo can publish and listen on different sockets

### DIFF
--- a/pkg/internal/config.go
+++ b/pkg/internal/config.go
@@ -27,6 +27,8 @@ type Config struct {
 	// PublishJson pushes socket updates as a JSON
 	// encoded status message instead of string formatted
 	PublishJson bool `json:"publishJson"`
+	// If Publish is true, provide a socket path to publish to
+	PublishSocketPath string `json:"publishSocketPath"`
 }
 
 type ColorMap struct {

--- a/pkg/internal/config.go
+++ b/pkg/internal/config.go
@@ -2,6 +2,7 @@ package pomo
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -118,5 +119,9 @@ func LoadConfig(configPath string, config *Config) error {
 	if config.IconPath == "" {
 		config.IconPath = path.Join(config.BasePath, "/icon.png")
 	}
+	if config.Publish && (config.PublishSocketPath == "" || config.PublishSocketPath == config.SocketPath) {
+		return fmt.Errorf("'publish' option now requires 'publishSocketPath' which must not be the same as 'socketPath'")
+	}
+
 	return nil
 }


### PR DESCRIPTION
This resolves #49

This is a breaking change for anyone that previously used "publish" mode, since the configuration for the socket path has changed.

I thought about what it would take to make this backwards compatible, and I'm wondering if it's worth the effort. It would need to check for the case where `publish` is `true`, and no `publishSocketPath` is set. In that case, `socketPath` would be copied to `publishSocketPath`, and each place I just changed in this PR to do both things would need to only do the publish thing, but only in this case.

Instead, I suggest an error indicating the change. That way, anyone using `publish` will know what happened and what they need to change.
