### PR TITLE
Fix for issue 44, runs always starting at 0 pomodoros

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -142,11 +142,6 @@ func begin(config *pomo.Config) func(*cli.Cmd) {
 					return err
 				}
 				task = read
-				err = db.DeletePomodoros(tx, *taskId)
-				if err != nil {
-					return err
-				}
-				task.Pomodoros = []*pomo.Pomodoro{}
 				return nil
 			}))
 			runner, err := pomo.NewTaskRunner(task, config)

--- a/pkg/internal/runner.go
+++ b/pkg/internal/runner.go
@@ -42,6 +42,7 @@ func NewTaskRunner(task *Task, config *Config) (*TaskRunner, error) {
 		return nil, err
 	}
 	tr := &TaskRunner{
+		count:        len(task.Pomodoros),
 		taskID:       task.ID,
 		taskMessage:  task.Message,
 		nPomodoros:   task.NPomodoros,

--- a/pkg/internal/store.go
+++ b/pkg/internal/store.go
@@ -123,6 +123,13 @@ func (s Store) ReadTask(tx *sql.Tx, taskID int) (*Task, error) {
 	if tags != "" {
 		task.Tags = strings.Split(tags, ",")
 	}
+	pomodoros, err := s.ReadPomodoros(tx, task.ID)
+	if err != nil {
+		return nil, err
+	}
+	for _, pomodoro := range pomodoros {
+		task.Pomodoros = append(task.Pomodoros, pomodoro)
+	}
 	return task, nil
 }
 


### PR DESCRIPTION
Hello pomo maintainers,

here's a small change, giving the ability to resume tasks with pomodoros already fullfilled, as opposed to starting at zero with every `pomo begin`.