### PR TITLE
Makefile tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ LDFLAGS=\
 	pomo-build \
 	readme 
 
-default: bin/pomo
+default: bin/pomo test
 
 clean:
 	[[ -f bin/pomo ]] && rm bin/pomo || true
 
-bin/pomo: test
+bin/pomo:
 	cd cmd/pomo && \
 	go build -ldflags '${LDFLAGS}' -o ../../$@
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ test:
 	go test ./...
 	go vet ./...
 
+install:
+	go install ./cmd/...
+
 docs: www/data/readme.json
 	cd www && hugo -d ../docs
 


### PR DESCRIPTION
- Build before running tests.  Ran into an issue running the default `make` before the binary had been built.
- Adds a `go install` target