### PR TITLE
Execute command on state change

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ if [ "$POMO_STATE" == "COMPLETE" ] ; then
 fi
 ```
 
+See the `contrib` directory for user contributed scripts for use with `onEvent`.
+
 ## Integrations
 
 By default pomo will setup a Unix socket and serve it's status there.

--- a/README.md
+++ b/README.md
@@ -67,24 +67,29 @@ Example:
 
 ### Execute command on state change
 
-Pomo will execute the command specified in the array argument `onEvent` when the
-state changes.  The new state will be exported as an environment variable
-`POMO_STATE` for this command.  For example, to trigger a terminal bell when a
-session complete, add the following to `config.json`
-```
+Pomo will execute an arbitrary command specified in the array argument `onEvent`
+when the state changes.  The first element of this array should be the
+executable to run while the remaining elements are space delimited arguments.
+The new state will be exported as an environment variable `POMO_STATE` for this
+command.  Possible state values are `RUNNING`, `PAUSED`, `BREAKING`, or
+`COMPLETE`.
+
+
+For example, to trigger a terminal bell when a session completes, add the
+following to `config.json`:
+```json
 ...
-"onEvent": ["/bin/sh", "/path/to/script/my_script.sh"]
+"onEvent": ["/bin/sh", "/path/to/script/my_script.sh"],
 ...
 ```
 where the contents of `my_script.sh` are
-```
+```bash
 #!/bin/sh
 
 if [ "$POMO_STATE" == "COMPLETE" ] ; then
    echo -e '\a'
 fi
 ```
-Possible state values are `RUNNING`, `PAUSED`, `BREAKING`, or `COMPLETE`.
 
 ## Integrations
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,27 @@ Example:
 }
 ```
 
+### Execute command on state change
+
+Pomo will execute the command specified in the array argument `onEvent` when the
+state changes.  The new state will be exported as an environment variable
+`POMO_STATE` for this command.  For example, to trigger a terminal bell when a
+session complete, add the following to `config.json`
+```
+...
+"onEvent": ["/bin/sh", "/path/to/script/my_script.sh"]
+...
+```
+where the contents of `my_script.sh` are
+```
+#!/bin/sh
+
+if [ "$POMO_STATE" == "COMPLETE" ] ; then
+   echo -e '\a'
+fi
+```
+Possible state values are `RUNNING`, `PAUSED`, `BREAKING`, or `COMPLETE`.
+
 ## Integrations
 
 By default pomo will setup a Unix socket and serve it's status there.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ The new state will be exported as an environment variable `POMO_STATE` for this
 command.  Possible state values are `RUNNING`, `PAUSED`, `BREAKING`, or
 `COMPLETE`.
 
-
 For example, to trigger a terminal bell when a session completes, add the
 following to `config.json`:
 ```json

--- a/contrib/bell
+++ b/contrib/bell
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo -e '\e'

--- a/contrib/pomonag
+++ b/contrib/pomonag
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "$POMO_STATE" == "BREAKING" ] ; then
+    swaynag -m "It's time to take a break!"
+fi

--- a/pkg/internal/config.go
+++ b/pkg/internal/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	DBPath      string    `json:"dbPath"`
 	SocketPath  string    `json:"socketPath"`
 	IconPath    string    `json:"iconPath"`
+	OnEvent     []string  `json:"onEvent"`
 	// Publish pushes updates to the configured
 	// SocketPath rather than listening for requests
 	Publish bool `json:"publish"`

--- a/pkg/internal/runner.go
+++ b/pkg/internal/runner.go
@@ -80,7 +80,7 @@ func (t *TaskRunner) SetState(state State) {
 	t.state = state
 	// execute onEvent command if variable is set
 	if t.onEvent != nil {
-		t.runOnEvent()
+		go t.runOnEvent()
 	}
 }
 


### PR DESCRIPTION
A more general solution that supersedes #60 

- Adds environment variable (array) `onEvent` to specify command to be run after every state change (i.e. `RUNNING`, `PAUSED`, `BREAKING`, or `COMPLETE`)
- Passes newly set state to environment variable `POMO_STATE`
- Added examples to README